### PR TITLE
use asterisk to import all express exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module "morgan-body";
 
 declare module "morgan-body" {
-  import express from "express";
+  import * as express from "express";
   import * as stream from "stream";
 
   type DateTimeFormatType = "edt" | "clf" | "iso" | "utc";


### PR DESCRIPTION
After updating typescript I got this error when I ran `tsc && node dist/index.js`:
`
node_modules/morgan-body/index.d.ts:4:10 - error TS1259: Module '"/Users/myUsername/Code/myProject/backend/node_modules/@types/express/index"' can only be default-imported using the 'esModuleInterop' flag

4   import express from "express";
           ~~~~~~~

  node_modules/@types/express/index.d.ts:106:1
    106 export = e;
        ~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
`
This change seems to fix the issue.