### PR TITLE
#21 Add filterParameters option to hide sensitive data

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ morganBody(app);
     stream: (default: null), optionally provide a stream (or any object of the shape { write: <Function> }) to be used instead of "process.stdout" for logging to,
 
     theme: (default: 'defaultTheme'), alter the color scheme of your logger with a theme, see available themes below
+
+    filterParameters: (default: []), set the properties you don't want to be shown, such as passwords or credit card numbers
   }
   ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ declare module "morgan-body" {
     skip?: FilterFunctionType | null;
     stream?: StreamLikeType | null;
     theme?: ThemeType;
+    filterParameters?: string[];
   }
 
   export default function morganBody(app: express.Application, options?: IMorganBodyOptions): void;

--- a/test/index.js
+++ b/test/index.js
@@ -265,6 +265,31 @@ describe('morganBody()', function () {
     });
   });
 
+  it('"filterParameters" property should hide sensitive data', function () {
+    const sharedStr = `\u001b[97m{\u001b[0m
+\u001b[97m\t"key": "value",\u001b[0m
+\u001b[97m\t"password": "[FILTERED]"\u001b[0m
+\u001b[97m}\u001b[0m
+`;
+
+    const consoleTestPromise = consoleTest(
+      standardPostRequestLineCheck,
+      line => expect(line).to.equal(`\u001b[95m[-] Request Body:\u001b[0m\n` + sharedStr),
+      line => expect(line).to.equal(`\u001b[95m[-] Response Body:\u001b[0m\n` + sharedStr),
+      standardResponseLineCheck
+    );
+
+    simulateRequestPromise({filterParameters: ['password'] }, 'post', {
+      key: 'value',
+      password: 'SuperSecretPassword'
+    }, {
+      key: 'value',
+      password: 'SuperSecretPassword'
+    });
+
+    return consoleTestPromise;
+  });
+
   describe('theme tests', () => {
     const getBodyStr = colorNumberStr => `\u001b[${colorNumberStr}m{\u001b[0m
 \u001b[${colorNumberStr}m\t"key": "value",\u001b[0m


### PR DESCRIPTION
Hi, I added a new `filterParameters` option to set properties that contain sensitive data. Those values properties will be printed as `[FILTERED]`. It's based on the way it is done in [rails](https://guides.rubyonrails.org/configuring.html) (search for `filter_parameters`). 

Example output from the test:
```
[-] Request: POST / at Wed Dec 31 1969 19:00:00 GMT-0500, User Agent: node-superagent/3.8.3
[-] Request Body:
{
        "key": "value",
        "password": "[FILTERED]"
}
[-] Response Body:
{
        "key": "value",
        "password": "[FILTERED]"
}
[-] Response: 200 0.168 ms 
    √ "filterParameters" property should hide sensitive data (62ms)`
```