### PR TITLE
[Work in progress] Transports & Metadata logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /node_modules
+
+/expressus

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ morganBody(app);
 
     logAllResHeader: (default: false), true will log All response headers and take precedence over logResHeaderList; false otherwise.
 
+    logMetadata: (default: false), true will log req.metadata, which can be passed through middleware; false otherwise.
+
     skip: (default: null), optionally provide function of the signature "(req, res) => <bool>" to conditionally skip logging of requests (if provided function returns true),
 
     stream: (default: null), optionally provide a stream (or any object of the shape { write: <Function> }) to be used instead of "process.stdout" for logging to,

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,9 +5,19 @@ declare module "morgan-body" {
   import * as stream from "stream";
 
   type DateTimeFormatType = "edt" | "clf" | "iso" | "utc";
-  type FilterFunctionType = (request: express.Request, response: express.Response) => boolean;
+  type FilterFunctionType = (
+    request: express.Request,
+    response: express.Response
+  ) => boolean;
   type StreamLikeType = stream.Writable | { write: stream.Writable["write"] };
-  type ThemeType = "defaultTheme" | "dracula" | "usa" | "inverted" | "darkened" | "lightened" | "dimmed";
+  type ThemeType =
+    | "defaultTheme"
+    | "dracula"
+    | "usa"
+    | "inverted"
+    | "darkened"
+    | "lightened"
+    | "dimmed";
 
   interface IMorganBodyOptions {
     noColors?: boolean;
@@ -24,13 +34,20 @@ declare module "morgan-body" {
     logRequestId?: boolean;
     logResHeaderList?: boolean;
     logAllResHeader?: boolean;
-    logIP?: boolean,
+    logIP?: boolean;
     skip?: FilterFunctionType | null;
     stream?: StreamLikeType | null;
     theme?: ThemeType;
     filterParameters?: string[];
   }
 
-  export default function morganBody(app: express.Application, options?: IMorganBodyOptions): void;
-}
+  interface ITransport {
+    transport: BaseTransport;
+    options?: IMorganBodyOptions;
+  }
 
+  export default function morganBody(
+    app: express.Application,
+    transports?: ITransport[]
+  ): void;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,7 @@ declare module "morgan-body" {
     logResHeaderList?: boolean;
     logAllResHeader?: boolean;
     logIP?: boolean;
+    logMetadata: boolean;
     skip?: FilterFunctionType | null;
     theme?: ThemeType;
     filterParameters?: string[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,6 @@ declare module "morgan-body" {
     logAllResHeader?: boolean;
     logIP?: boolean;
     skip?: FilterFunctionType | null;
-    stream?: StreamLikeType | null;
     theme?: ThemeType;
     filterParameters?: string[];
   }

--- a/index.js
+++ b/index.js
@@ -164,12 +164,12 @@ function bodyToString(maxBodyLength, prettify, prependStr, body, bodyActionColor
   }
 
   if (isString && body.length) {
-    finalStr += bodyActionColor + prependStr + ' Body:' + defaultColor + '\n';
+    finalStr += bodyActionColor + prependStr + (prependStr === 'Metadata' ? ':' : ' Body:') + defaultColor + '\n';
 
     if (body.length > maxBodyLength) body = body.slice(0, maxBodyLength) + '\n...';
     finalStr += bodyColor + body.slice(0, maxBodyLength) + defaultColor;
   } else if(isObj && Object.keys(body).length > 0) {
-    finalStr += bodyActionColor + prependStr + ' Body:' + defaultColor;
+    finalStr += bodyActionColor + prependStr + (prependStr === 'Metadata' ? ':' : ' Body:') + defaultColor;
 
     var jsonSeparator = prettify === true ? '\t' : null;
     var stringifiedObj = JSON.stringify(body, (key, value) => {
@@ -247,6 +247,7 @@ function logger(app, options) {
   var logResponseBody = options.hasOwnProperty('logResponseBody') ? options.logResponseBody : true;
   var logRequestId = options.hasOwnProperty('logRequestId') ? options.logRequestId : false;
   var logIP = options.hasOwnProperty('logIP') ? options.logIP : true;
+  var logMetadata = options.hasOwnProperty('logMetadata') ? options.logMetadata : false;
   var timezone = options.hasOwnProperty('timezone') ? options.timezone || 'local' : 'local';
   var noColors = options.hasOwnProperty('noColors') ? options.noColors : false;
   var prettify = options.hasOwnProperty('prettify') ? options.prettify : true;
@@ -299,6 +300,9 @@ function logger(app, options) {
   if (options.hasOwnProperty('logIP')) {
       morganOptions.logIP = options.logIP
   }
+  if (options.hasOwnProperty('logMetadata')) {
+    morganOptions.logMetadata = options.logMetadata
+}
 
   morganOptions.prettify = prettify; // needs to be passed to modify output stream separator
 
@@ -399,6 +403,10 @@ function logger(app, options) {
       };
 
       app.use(morgan(logBodyGen('Response', (req, res) => res.__morgan_body_response), morganOptions));
+    }
+
+    if (logMetadata) {
+        app.use(morgan(logBodyGen('Metadata', (req, res) => req.metadata), morganOptions));
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -188,7 +188,52 @@ function bodyToString(maxBodyLength, prettify, prependStr, body, bodyActionColor
   return finalStr || null; // must return "null" to avoid morgan logging blank line
 }
 
-module.exports = function morganBody(app, options) {
+module.exports = function morganBody(app, transports) {
+    if (!transports) {
+      transports = [
+        {
+          transport: new ConsoleTransport(),
+          options: {
+            maxBodyLength: 1000,
+            logReqDateTime: true,
+            logAllReqHeader: false,
+            logAllResHeader: false,
+            logReqHeaderList: null,
+            logResHeaderList: null,
+            logReqUserAgent: true,
+            logRequestBody: true,
+            logResponseBody: true,
+            logRequestId: false,
+            logIP: true,
+            timezone: "local",
+            noColors: false,
+            prettify: true,
+            filterParameters: [],
+          },
+        },
+      ];
+    }
+
+    for (const t of transports) {
+        if (t.hasOwnProperty("transport")) {
+            const { transport, options } = t
+
+            if (typeof transport.write !== 'function') {
+                console.error("ERROR: One of the passed transports is missing function write()")
+            } else {
+                logger(app, {
+                    ...options,
+                    stream: transport
+                })
+            }
+        } else {
+            console.error("ERROR: One of the passed transports is missing the required property 'transport'!")
+        }
+    }
+};
+
+
+function logger(app, options) {
   // default options
   options = options || {};
   var maxBodyLength = options.hasOwnProperty('maxBodyLength') ? options.maxBodyLength : 1000;
@@ -409,6 +454,7 @@ module.exports = function morganBody(app, options) {
 
 var onFinished = require('on-finished');
 var onHeaders = require('on-headers');
+const ConsoleTransport = require('./transports/ConsoleTransport');
 
 /**
  * Array of CLF month names.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "morgan-body",
-  "version": "2.4.14",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/util/simulateRequestPromise.js
+++ b/test/util/simulateRequestPromise.js
@@ -2,6 +2,7 @@ var http = require('http');
 var request = require('supertest');
 var bodyParser = require('body-parser');
 var morganBody = require('../..');
+const ConsoleTransport = require('../../transports/ConsoleTransport');
 
 
 module.exports = function simulateRequestPromise(opts, method = 'get', reqBody, resBody, addToRequestObj = {}) {
@@ -34,7 +35,12 @@ function createServer(opts, responseObj, addToRequestObj) {
       req[key] = addToRequestObj[key];
     });
 
-    morganBody(fakeApp, opts || {});
+    morganBody(fakeApp, [
+        {
+            transport: new ConsoleTransport(),
+            options: opts
+        }
+    ]);
 
     res.send = fakeApp.response.send.bind(res);
 

--- a/transports/BaseTransport.js
+++ b/transports/BaseTransport.js
@@ -1,0 +1,5 @@
+class BaseTransport {
+  write(string) {}
+}
+
+module.exports = BaseTransport;

--- a/transports/ConsoleTransport.js
+++ b/transports/ConsoleTransport.js
@@ -1,0 +1,15 @@
+const BaseTransport = require("./BaseTransport");
+
+class ConsoleTransport extends BaseTransport {
+
+    constructor() {
+        super()
+    }
+
+    write(message) {
+        console.log(message)
+    }
+
+}
+
+module.exports = ConsoleTransport

--- a/transports/FileTransport.js
+++ b/transports/FileTransport.js
@@ -1,0 +1,10 @@
+const fs = require("fs");
+const StreamTransport = require("./StreamTransport");
+
+class FileTransport extends StreamTransport {
+  constructor(file) {
+    super(fs.createWriteStream(file, { flags: "a" }));
+  }
+}
+
+module.exports = FileTransport;

--- a/transports/StreamTransport.js
+++ b/transports/StreamTransport.js
@@ -1,0 +1,18 @@
+const BaseTransport = require("./BaseTransport");
+
+class StreamTransport extends BaseTransport {
+
+    stream;
+
+    constructor(stream) {
+        super()
+        this.stream = stream
+    }
+
+    write(message) {
+        this.stream.write(message)
+    }
+
+}
+
+module.exports = StreamTransport


### PR DESCRIPTION
Hello, today I'd like to present you 2 new features:

1. Transports - Transports are classes that take care of well, transporting the log to some place. Users can create their own transports by creating a class that extends BaseTransport, but there are also premade ones - at the moment it's ConsoleTransport, FileTransport and StreamTransport.

2. Logging Metadata - Let's say you have a middleware, it takes care of identifying an user that's using your app. You pass that data, and there it ends. But what if you want to log that data, so you know who was it that was trying to use your app? With  this new feature, all you have to do is pass all that data to `req.metadata`, and MorganBody will log it! This idea came up from issue #28.

Sincerely,
Vottus