### PR TITLE
new option logNewLine added - issue #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ morganBody(app, {
     maxBodyLength: (default: 1000), caps the length of the console output of a single request/response to specified length,
 
 
-    prettify: (default: true), prettifies the JSON request/response body (may want to turn off for server logs),
+    prettify: (default: true), prettifies the JSON request/response body (may want to turn off for server logs) and adds new line after each log entry irrespective of logNewLine option,
+
+    logNewLine: (default: false), adds new line after each log entry. can enable new line prettify is false,
 
     logReqDateTime: (default: true), setting to false disables logging request date + time,
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ declare module "morgan-body" {
     logResHeaderList?: boolean;
     logAllResHeader?: boolean;
     logIP?: boolean,
+    logNewLine?:boolean;
     skip?: FilterFunctionType | null;
     stream?: StreamLikeType | null;
     theme?: ThemeType;

--- a/index.js
+++ b/index.js
@@ -206,6 +206,8 @@ module.exports = function morganBody(app, options) {
   var noColors = options.hasOwnProperty('noColors') ? options.noColors : false;
   var prettify = options.hasOwnProperty('prettify') ? options.prettify : true;
   var filterParameters = options.hasOwnProperty('filterParameters') ? options.filterParameters : [];
+  var logNewLine = options.hasOwnProperty('logNewLine') ? options.logNewLine : false;
+
 
   var theme;
   if (noColors) {
@@ -256,6 +258,7 @@ module.exports = function morganBody(app, options) {
   }
 
   morganOptions.prettify = prettify; // needs to be passed to modify output stream separator
+  morganOptions.logNewLine = logNewLine; // needs to be passed to modify output stream separator even when prettify is set to false
 
   const optionalIdInclusionStr = logRequestId ? '[:id] ' : '';
 
@@ -480,7 +483,8 @@ function morgan(format, opts) {
     // record request start
     recordStartTime.call(req);
 
-    var lineSeparator = opts.prettify === true ? '\n' : '';
+    var lineSeparator = getLineSeperator(opts);
+  
     function logRequest() {
       if (skip !== false && skip(req, res)) {
         return;
@@ -865,4 +869,13 @@ function recordStartTime() {
 function token(name, fn) {
   morgan[name] = fn;
   return this;
+}
+
+
+function getLineSeperator(opts){
+  if(opts.prettify===true || opts.logNewLine===true){
+    return '\n';
+  } else {
+    return '';
+  }
 }


### PR DESCRIPTION
logNewLine is added is a new option .. By default set as false . if prettify is false . new line is not logged after each log entry .

Users can enable new lines now even when prettify is false by setting the option logNewLine as true