### PR TITLE
Fix logReqHeaderList type as list

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ declare module "morgan-body" {
     timezone?: string;
     logReqUserAgent?: boolean;
     logRequestBody?: boolean;
-    logReqHeaderList?: boolean;
+    logReqHeaderList?: string[];
     logAllReqHeader?: boolean;
     logResponseBody?: boolean;
     logRequestId?: boolean;


### PR DESCRIPTION
`logReqHeaderList` accepts a list of headers, whereas it is typed as boolean.