### PR TITLE
Overwriting send prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -373,8 +373,9 @@ module.exports = function morganBody(app, options) {
 
     if (logResponseBody) {
       // need to catch setting of response body
-      var originalSend = app.response.send;
-      app.response.send = function sendOverWrite(body) {
+      const appResponsePrototype = Object.getPrototypeOf(app.response);
+      var originalSend = appResponsePrototype.send;
+      appResponsePrototype.send = function sendOverWrite(body) {
         originalSend.call(this, body);
         this.__morgan_body_response = body;
       };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "morgan-body",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morgan-body",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "author": "Roger Beaman <rwcbeaman@gmail.com> (https://github.com/sirrodgepodge)",
   "description": "morgan logging req, res, and body",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morgan-body",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "author": "Roger Beaman <rwcbeaman@gmail.com> (https://github.com/sirrodgepodge)",
   "description": "morgan logging req, res, and body",
   "main": "index.js",

--- a/test/util/simulateRequestPromise.js
+++ b/test/util/simulateRequestPromise.js
@@ -19,14 +19,18 @@ module.exports = function simulateRequestPromise(opts, method = 'get', reqBody, 
 
 function createServer(opts, responseObj, addToRequestObj) {
   var funcPipeline = [];
-  var fakeApp = {
+
+  class FakeAppResponse {
+    send() {}
+  }
+  class FakeApp {
     use(func) {
       funcPipeline.push(func);
-    },
-    response: {
-      send() {}
     }
-  };
+    response = new FakeAppResponse()
+  }
+
+  var fakeApp = new FakeApp();
 
   return http.createServer(function onRequest (req, res) {
     // add properties to request object
@@ -35,7 +39,6 @@ function createServer(opts, responseObj, addToRequestObj) {
     });
 
     morganBody(fakeApp, opts || {});
-
     res.send = fakeApp.response.send.bind(res);
 
     // run middleware consecutively with req and res, some mini-express action here


### PR DESCRIPTION
this is done in order to handle libraries such as `sentry` (https://github.com/getsentry/sentry-javascript/blob/master/packages/tracing/src/integrations/node/express.ts#L286) which overwrite express methods at the prototype level and presently conflict with morgan-body, breaking it